### PR TITLE
retry auth fetch on error

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -213,7 +213,11 @@ func (a *Auth) Credentials() (accesskey, secretKey, token string) {
 	}
 
 	// token expired
-	newAuth, _ := GetAuth("", "", "", time.Time{})
+	newAuth, err := GetAuth("", "", "", time.Time{})
+	if err != nil {
+		// we can't do much here. the next caller will try again.
+		return "", "", ""
+	}
 
 	a.mu.Lock()
 	defer a.mu.Unlock()


### PR DESCRIPTION
I was trying to make the minimal set of changes to make this goroutine safe but missed something. When this returns an error `expiration` is likely set to 0. A few lines up checks to see if `expiration`is 0 and doesn't check for expiration if so so the instance will be stuck with an invalid token forever. I guess it's not unheard of for the instance metadata service to occasionally return errors.